### PR TITLE
add-patch: Stop depending on `the_repository`

### DIFF
--- a/repo-settings.c
+++ b/repo-settings.c
@@ -148,6 +148,8 @@ void prepare_repo_settings(struct repository *r)
 
 	if (!repo_config_get_ulong(r, "core.packedgitlimit", &ulongval))
 		r->settings.packed_git_limit = ulongval;
+	
+	r->settings.comment_line_str = '#';
 }
 
 void repo_settings_clear(struct repository *r)

--- a/repo-settings.h
+++ b/repo-settings.h
@@ -67,6 +67,9 @@ struct repo_settings {
 	unsigned long big_file_threshold;
 
 	char *hooks_path;
+
+	char *comment_line_str;
+
 };
 #define REPO_SETTINGS_INIT { \
 	.shared_repository = -1, \

--- a/repository.c
+++ b/repository.c
@@ -57,7 +57,6 @@ void initialize_repository(struct repository *repo)
 	repo->parsed_objects = parsed_object_pool_new(repo);
 	ALLOC_ARRAY(repo->index, 1);
 	index_state_init(repo->index, repo);
-
 	/*
 	 * When a command runs inside a repository, it learns what
 	 * hash algorithm is in use from the repository, but some

--- a/repository.h
+++ b/repository.h
@@ -154,6 +154,7 @@ struct repository {
 
 	/* Indicate if a repository has a different 'commondir' from 'gitdir' */
 	unsigned different_commondir:1;
+		
 };
 
 #ifdef USE_THE_REPOSITORY_VARIABLE


### PR DESCRIPTION
Remove the dependency of `the_repository` in add-patch.c and also shift the global environment variable `comment_line_str` to repo_settings. This change removes the `#define USE_THE_REPOSITORY_VARIABLE` definition from add-patch.c.
